### PR TITLE
Catching the exception when the hideKeyBoard() throws errors when the soft keyboard is not visible.

### DIFF
--- a/CodeBySpecification/.vs/config/applicationhost.config
+++ b/CodeBySpecification/.vs/config/applicationhost.config
@@ -179,7 +179,7 @@
             </site>
             <site name="SampleWebProject" id="4">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="E:\Projects\CodeSpec\SampleProjects\SampleWebProject" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\MILINDUK\Documents\CodeSpec\SampleProjects\SampleWebProject" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:50400:localhost" />

--- a/CodeBySpecification/CodeSpecSampleTest/App.config
+++ b/CodeBySpecification/CodeSpecSampleTest/App.config
@@ -13,8 +13,9 @@
   <appSettings>
     <add key="UI.Tests.SUT.Url" value="http://localhost:50400"/>
     <add key="UI.Tests.Timeout" value="10"/>
-    <add key="UI.Tests.Target.Browser" value="Android"/>
+    <add key="UI.Tests.Target.Browser" value="FireFox"/>
     <add key="UI.Tests.Target.URI" value="http://127.0.0.1:4723/wd/hub"/>
+    <add key="UI.Tests.Appium.Platform" value="Android"/>
     <add key="UI.Tests.Appium.capability.deviceName" value="Android Emulator"/>
     
     <!-- At the moment no other browser is supported -->

--- a/CodeBySpecification/Selenium.Base/Service/AppiumUiAutomationServices.cs
+++ b/CodeBySpecification/Selenium.Base/Service/AppiumUiAutomationServices.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium;
 
 namespace Selenium.Base.Service
 {
@@ -13,8 +14,17 @@ namespace Selenium.Base.Service
         public override void EnterTextTo(string elementKey, string text, string selectionMethod = null, string selection = null)
         {
             base.EnterTextTo(elementKey, text, selectionMethod, selection);
-            var driver = ((AndroidDriver<AndroidElement>)GetBrowser);
-            driver.HideKeyboard();
+            var driver = ((AndroidDriver<AppiumWebElement>)GetBrowser);
+            try
+            {
+                driver.HideKeyboard();
+            }
+            catch (Exception)
+            {
+                //Catching the exception when the hideKeyBoard() throws errors when the soft keyboard is not visible.
+                //No other solution available at the moment, API does not have a way to check if the soft keyboard is visible still.
+
+            }
 
         }
     }

--- a/CodeBySpecification/Selenium.Base/Service/AppiumUiAutomationServices.cs
+++ b/CodeBySpecification/Selenium.Base/Service/AppiumUiAutomationServices.cs
@@ -21,14 +21,10 @@ namespace Selenium.Base.Service
             }
             catch (Exception)
             {
-<<<<<<< HEAD
+
                 //Catching the exception when the hideKeyBoard() throws errors when the soft keyboard is not visible.
                 //No other solution available at the moment, API does not have a way to check if the soft keyboard is visible still.
 
-=======
-
-                
->>>>>>> a5aa2ee2111ca5b11e4fc978daef508e6fbf230d
             }
 
         }

--- a/CodeBySpecification/Selenium.Base/Service/AppiumUiAutomationServices.cs
+++ b/CodeBySpecification/Selenium.Base/Service/AppiumUiAutomationServices.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium;
 
 namespace Selenium.Base.Service
 {
@@ -13,8 +14,16 @@ namespace Selenium.Base.Service
         public override void EnterTextTo(string elementKey, string text, string selectionMethod = null, string selection = null)
         {
             base.EnterTextTo(elementKey, text, selectionMethod, selection);
-            var driver = ((AndroidDriver<AndroidElement>)GetBrowser);
-            driver.HideKeyboard();
+            var driver = ((AndroidDriver<AppiumWebElement>)GetBrowser);
+            try
+            {
+                driver.HideKeyboard();
+            }
+            catch (Exception)
+            {
+
+                
+            }
 
         }
     }

--- a/CodeBySpecification/Selenium.Base/UIAutomation.Base.csproj
+++ b/CodeBySpecification/Selenium.Base/UIAutomation.Base.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Browsers\IEBrowser.cs" />
     <Compile Include="Browsers\FireFoxBrowser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Service\AppiumUiAutomationServices.cs" />
     <Compile Include="Service\SeleniumUiAutomationService.cs" />
   </ItemGroup>
   <ItemGroup />


### PR DESCRIPTION
No other solution available at the moment, API does not have a way to check if the soft keyboard is visible still.
