### PR TITLE
Improved the table grammar

### DIFF
--- a/CodeBySpecification/CodeBySpecification/Core/FeatureBase.cs
+++ b/CodeBySpecification/CodeBySpecification/Core/FeatureBase.cs
@@ -584,9 +584,9 @@ namespace CodeBySpecification.Core
 			}
 		}
 
-		[Given(@"""(.*)"".. row, ""(.*)"".. column of table ""(.*)"" contains value ""(.*)""")]
-		[When(@"""(.*)"".. row, ""(.*)"".. column of table ""(.*)"" contains value ""(.*)""")]
-        [Then(@"""(.*)"".. row, ""(.*)"".. column of table ""(.*)"" contains value ""(.*)""")]
+		[Given(@"""(.*)""(?:st|nd|rd|th) row, ""(.*)""(?:st|nd|rd|th) column of table ""(.*)"" contains value ""(.*)""")]
+		[When(@"""(.*)""(?:st|nd|rd|th) row, ""(.*)""(?:st|nd|rd|th) column of table ""(.*)"" contains value ""(.*)""")]
+        [Then(@"""(.*)""(?:st|nd|rd|th) row, ""(.*)""(?:st|nd|rd|th) column of table ""(.*)"" contains value ""(.*)""")]
         [Given(@"row ""(.*)"", column ""(.*)"" of table ""(.*)"" contains value ""(.*)""")]
         [When(@"row ""(.*)"" row, column ""(.*)"" of table ""(.*)"" contains value ""(.*)""")]
         [Then(@"row ""(.*)"" row, column ""(.*)"" of table ""(.*)"" contains value ""(.*)""")]


### PR DESCRIPTION
Using SpecFlow's non-capturing groups `(?:regex)` in order to use groups without a method argument.

```
""(.*)""(?:st|nd|rd|th) row, ""(.*)""(?:st|nd|rd|th) 
```
